### PR TITLE
dockerfile fix : Angular CLI Node.js mismatch

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,6 +1,6 @@
 ### STAGE 1: Build ###
 # We label our stage as ‘builder’
-FROM node:14.5-alpine as builder
+FROM node:14.15-alpine as builder
 
 COPY frontend/package.json frontend/package-lock.json ./
 

--- a/dockerfile
+++ b/dockerfile
@@ -15,7 +15,7 @@ COPY /frontend .
 RUN npm run build:prod
 
 ### STAGE 2: Setup ###
-FROM node:14.5-alpine
+FROM node:14.15-alpine
 
 ## channge directory
 WORKDIR /app


### PR DESCRIPTION
Node.js version v14.5.0 detected.
The Angular CLI requires a minimum Node.js version of either v12.14 or v14.15.

Please update your Node.js version or visit https://nodejs.org/ for additional instructions.
