### PR TITLE
seo: link out to the blog and the sibling doc sites

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -37,6 +37,12 @@ search_tokenizer_separator: /[\s/]+/
 aux_links:
   "View on GitHub":
     - "//github.com/nitin27may/mean-docker"
+  # This site had no link out of it anywhere -- not to the blog it is published
+  # under, not to its sibling doc sites. This one is the only project site Google
+  # has actually indexed, off an older crawl, so the equity it does carry was
+  # going nowhere. The three siblings below need it more than it does.
+  "nitinksingh.com":
+    - "/"
 
 # Footer content
 footer_content: "Copyright &copy; 2026 Nitin Singh. Distributed by an MIT license."
@@ -78,6 +84,17 @@ gh_edit_view_mode: "tree"
 nav_external_links:
   - title: MEAN Stack Contacts on GitHub
     url: https://github.com/nitin27may/mean-docker
+    hide_icon: false
+  # The sibling doc sites, all published under the same domain. Trailing slashes
+  # are required: GitHub Pages 301s the unslashed form of a directory index.
+  - title: AI Knowledge Hub
+    url: https://nitinksingh.com/ai-resources/
+    hide_icon: false
+  - title: E-Commerce Agents
+    url: https://nitinksingh.com/e-commerce-agents/
+    hide_icon: false
+  - title: Clean Architecture Starter
+    url: https://nitinksingh.com/clean-architecture-docker-dotnet-angular/
     hide_icon: false
 
 # Back to top link


### PR DESCRIPTION
## Why

This site is a leaf — every link in it points back into itself. Nothing goes to `nitinksingh.com`, which it's published under, and nothing to the three sibling doc sites on the same domain.

A crawl of all four project sites found the same shape in every one, and Search Console shows the consequence: clean-architecture, ai-resources and e-commerce-agents are all **"URL is unknown to Google"** — never crawled once, because nothing on the web points at them.

mean-docker is the exception: it's the only project site Google has actually indexed, off an older crawl. So the equity it *does* carry was going nowhere, and the three siblings need it more than it does.

## What changed

`docs/_config.yml` only.

- `aux_links` renders top-right on every page, so one key buys a site-wide link back to the blog.
- `nav_external_links` gets the three siblings.

Trailing slashes are deliberate — GitHub Pages 301s the unslashed form of a directory index, and there's no reason to spend a redirect hop on our own navigation.

## Verification

Built with the real CI image (`ghcr.io/actions/jekyll-build-pages`): the built index emits a link to `/` plus all three siblings, and still renders exactly one `<h1>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)