### PR TITLE
Add an identical blog back-link footer across all four doc sites

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -46,29 +46,17 @@ aux_links:
 
 # Footer content
 # Site-wide footer. Identical on all four doc sites by design, so the family
-# reads as one property rather than four unrelated microsites. It lives in the
-# footer rather than only in aux_links/nav because the footer renders on EVERY
-# page, while aux_links reads as chrome and is easy to miss.
+# reads as one property rather than four unrelated microsites -- keep it
+# byte-identical when editing.
 #
-# Raw HTML is safe here: the theme interpolates this value without escaping
-# (verified against live output -- `&copy;` arrives as an entity, not
-# `&amp;copy;`).
+# It lives in the footer rather than only in aux_links because the footer
+# renders on EVERY page, while aux_links reads as chrome and is easy to miss.
+# Raw HTML is safe: the theme interpolates this without escaping (verified
+# against live output -- `&copy;` arrives as an entity, not `&amp;copy;`).
 #
-# Each site links to itself as well as its siblings. That is deliberate: it is
-# what keeps the string byte-identical across all four repos, so the footer can
-# be copied between them without a per-site diff to reconcile.
-#
-# NOTE: an earlier revision carried a per-repo TOPICAL deep link here (e.g. the
-# Clean Architecture series for that repo), which carries more ranking signal
-# than a homepage link. That is incompatible with a uniform footer and was
-# dropped on purpose. If those are wanted back, nav_external_links is the place
-# -- it is already per-site, so it can differ without breaking this.
-footer_content: >-
-  &copy; 2026 <a href="https://nitinksingh.com/">Nitin Singh</a> &middot; MIT License
-  &middot; <a href="https://nitinksingh.com/ai-resources/">AI Knowledge Hub</a>
-  &middot; <a href="https://nitinksingh.com/e-commerce-agents/">E-Commerce Agents</a>
-  &middot; <a href="https://nitinksingh.com/clean-architecture-docker-dotnet-angular/">Clean Architecture</a>
-  &middot; <a href="https://nitinksingh.com/mean-docker/">MEAN Stack</a>
+# Sibling doc-site links are deliberately NOT here; they live in
+# nav_external_links below, which is per-site and can differ freely.
+footer_content: '&copy; 2026 <a href="https://nitinksingh.com/">Nitin Singh</a> &middot; MIT License'
 
 # Color scheme supports "light" (default) and "dark"
 color_scheme: light

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -64,8 +64,7 @@ aux_links:
 # dropped on purpose. If those are wanted back, nav_external_links is the place
 # -- it is already per-site, so it can differ without breaking this.
 footer_content: >-
-  &copy; 2026 Nitin Singh &middot; MIT License
-  &middot; <a href="https://nitinksingh.com/">nitinksingh.com</a>
+  &copy; 2026 <a href="https://nitinksingh.com/">Nitin Singh</a> &middot; MIT License
   &middot; <a href="https://nitinksingh.com/ai-resources/">AI Knowledge Hub</a>
   &middot; <a href="https://nitinksingh.com/e-commerce-agents/">E-Commerce Agents</a>
   &middot; <a href="https://nitinksingh.com/clean-architecture-docker-dotnet-angular/">Clean Architecture</a>

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -45,7 +45,22 @@ aux_links:
     - "/"
 
 # Footer content
-footer_content: "Copyright &copy; 2026 Nitin Singh. Distributed by an MIT license."
+# Site-wide footer. The blog back-link lives here rather than only in
+# aux_links because footer_content renders on EVERY page, while aux_links reads
+# as chrome and is easy to miss. Raw HTML is safe: just-the-docs interpolates
+# footer_content without escaping (verified against live output -- `&copy;`
+# arrives as an entity, not `&amp;copy;`).
+#
+# Two links, both deliberate:
+#  - the parent site, so this doc site is not a dead end;
+#  - a TOPICAL deep link, which carries far more ranking signal than another
+#    homepage link. mean-docker has no dedicated blog post -- only a passing
+#    mention in the Codespaces article -- so the Docker category is the closest
+#    honest match. If a MEAN/Docker post is ever written, point this at it.
+footer_content: >-
+  Copyright &copy; 2026 Nitin Singh. Distributed by an MIT license.
+  &middot; Part of <a href="https://nitinksingh.com/">nitinksingh.com</a>
+  &middot; <a href="https://nitinksingh.com/categories/docker/">Docker articles on the blog</a>
 
 # Color scheme supports "light" (default) and "dark"
 color_scheme: light

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -58,9 +58,9 @@ aux_links:
 #    mention in the Codespaces article -- so the Docker category is the closest
 #    honest match. If a MEAN/Docker post is ever written, point this at it.
 footer_content: >-
-  Copyright &copy; 2026 Nitin Singh. Distributed by an MIT license.
-  &middot; Part of <a href="https://nitinksingh.com/">nitinksingh.com</a>
-  &middot; <a href="https://nitinksingh.com/categories/docker/">Docker articles on the blog</a>
+  &copy; 2026 Nitin Singh &middot; MIT License
+  &middot; <a href="https://nitinksingh.com/">nitinksingh.com</a>
+  &middot; <a href="https://nitinksingh.com/categories/docker/">Docker articles</a>
 
 # Color scheme supports "light" (default) and "dark"
 color_scheme: light

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -45,22 +45,31 @@ aux_links:
     - "/"
 
 # Footer content
-# Site-wide footer. The blog back-link lives here rather than only in
-# aux_links because footer_content renders on EVERY page, while aux_links reads
-# as chrome and is easy to miss. Raw HTML is safe: just-the-docs interpolates
-# footer_content without escaping (verified against live output -- `&copy;`
-# arrives as an entity, not `&amp;copy;`).
+# Site-wide footer. Identical on all four doc sites by design, so the family
+# reads as one property rather than four unrelated microsites. It lives in the
+# footer rather than only in aux_links/nav because the footer renders on EVERY
+# page, while aux_links reads as chrome and is easy to miss.
 #
-# Two links, both deliberate:
-#  - the parent site, so this doc site is not a dead end;
-#  - a TOPICAL deep link, which carries far more ranking signal than another
-#    homepage link. mean-docker has no dedicated blog post -- only a passing
-#    mention in the Codespaces article -- so the Docker category is the closest
-#    honest match. If a MEAN/Docker post is ever written, point this at it.
+# Raw HTML is safe here: the theme interpolates this value without escaping
+# (verified against live output -- `&copy;` arrives as an entity, not
+# `&amp;copy;`).
+#
+# Each site links to itself as well as its siblings. That is deliberate: it is
+# what keeps the string byte-identical across all four repos, so the footer can
+# be copied between them without a per-site diff to reconcile.
+#
+# NOTE: an earlier revision carried a per-repo TOPICAL deep link here (e.g. the
+# Clean Architecture series for that repo), which carries more ranking signal
+# than a homepage link. That is incompatible with a uniform footer and was
+# dropped on purpose. If those are wanted back, nav_external_links is the place
+# -- it is already per-site, so it can differ without breaking this.
 footer_content: >-
   &copy; 2026 Nitin Singh &middot; MIT License
   &middot; <a href="https://nitinksingh.com/">nitinksingh.com</a>
-  &middot; <a href="https://nitinksingh.com/categories/docker/">Docker articles</a>
+  &middot; <a href="https://nitinksingh.com/ai-resources/">AI Knowledge Hub</a>
+  &middot; <a href="https://nitinksingh.com/e-commerce-agents/">E-Commerce Agents</a>
+  &middot; <a href="https://nitinksingh.com/clean-architecture-docker-dotnet-angular/">Clean Architecture</a>
+  &middot; <a href="https://nitinksingh.com/mean-docker/">MEAN Stack</a>
 
 # Color scheme supports "light" (default) and "dark"
 color_scheme: light


### PR DESCRIPTION
Adds one **identical** footer to all four doc sites, linking back to the blog.

## The footer

`© 2026 `**`Nitin Singh`**` · MIT License`

"Nitin Singh" links to `https://nitinksingh.com/`. Byte-identical in all four repos — keep it that way when editing.

## Why the footer

`aux_links` / `nav` already link out, but they render as chrome and are easy to miss. The footer renders on **every page**, so this is a consistent site-wide signal.

## Outbound links after this change

| Site | Unique outbound links | Source |
|---|---|---|
| mean-docker | 5 | footer + `nav_external_links` |
| clean-architecture | 5 | footer + `nav_external_links` |
| e-commerce-agents | 5 | footer + `nav_external_links` |
| **ai-resources** | **2** | footer only |

**ai-resources is a real reduction.** It has no `nav_external_links`, so the footer was its only outbound path — it now links to the blog and nothing else. The sibling sites remain reachable from each other and from the blog, so nothing is orphaned, but this site no longer links sideways. `nav` is the place to restore it if wanted; noted in the config comment.

## Gotcha for the MkDocs config

The value **must stay quoted**. Unquoted, YAML reads a leading `&` as an anchor indicator, so `&copy;` is a syntax error and `mkdocs build` aborts. The three Jekyll configs quote it too.

## Verification

Built with the real CI toolchain, not assumed:

| Site | Indexable pages | Carrying the footer |
|---|---|---|
| mean-docker | 11 | 11 |
| clean-architecture | 12 | 12 |
| e-commerce-agents | 85 | 85 |
| ai-resources | 45 | 45 |

- Pages without a footer are `noindex` redirect stubs — correct, not a gap
- e-commerce-agents still renders exactly one `<h1>` on all 85 pages
- `mkdocs build --strict` passes clean

Generated with [Claude Code](https://claude.com/claude-code)