### PR TITLE
Show the GitHub star count in the site header

### DIFF
--- a/docs/_includes/header_custom.html
+++ b/docs/_includes/header_custom.html
@@ -1,0 +1,34 @@
+{%- comment -%}
+Live star count in the site header.
+
+just-the-docs renders this include inside `#main-header`, between the search box
+and `aux_nav` -- see the theme's `_includes/components/header.html`. It is an
+official extension point, so nothing from the remote theme has to be vendored
+here and a theme upgrade cannot silently drop this.
+
+Why it exists: the three MkDocs Material sibling sites display a star count
+natively (Material fetches it client-side from the GitHub API). just-the-docs has
+no equivalent, so this site showed nothing -- 118 stars sitting invisible on
+the project's own documentation. Social proof only: there is deliberately no
+"please star this repo" copy anywhere on the site.
+
+`.main-header` is `display: flex; justify-content: space-between` at the `md`
+breakpoint. With three children the middle one would strand in the centre, so
+`margin-left: auto` parks the badge against the aux links instead. Below `md` the
+whole header is `display: none`, so this is desktop-only by the theme's own design.
+
+The image carries `height` but NOT `width`: shields.io sizes the badge to its
+content, so a hardcoded width would squash the digits the day the count gains one.
+`min-width` on the wrapper reserves the horizontal space instead, which is what
+actually prevents layout shift. Lazy + async because a decorative badge should
+never block the header.
+{%- endcomment -%}
+<div class="header-star-count" style="display:flex;align-items:center;margin-left:auto;padding:0 1rem;min-width:121px;">
+  <a href="https://github.com/nitin27may/mean-docker/stargazers"
+     title="Star mean-docker on GitHub"
+     aria-label="Star mean-docker on GitHub">
+    <img src="https://img.shields.io/github/stars/nitin27may/mean-docker?style=flat&logo=github&label=Star&color=0f766e"
+         alt="GitHub stars for nitin27may/mean-docker"
+         height="20" loading="lazy" decoding="async">
+  </a>
+</div>


### PR DESCRIPTION
## Why

This repo has **118 stars and 71 forks** and its own documentation site showed neither.

The three sibling MkDocs Material sites (`ai-resources`, `mcp-generator`, `ms-graph-mcp`) display a star count natively — Material fetches it client-side from the GitHub API. just-the-docs has no equivalent, so the three Jekyll sites showed nothing. The result was an inversion: **206 of the 207 stars across the six doc sites sat on the three sites that displayed none of them.**

## What

One new file, `docs/_includes/header_custom.html`, rendering a shields.io star badge.

`header_custom.html` is an official just-the-docs extension point — the theme renders it inside `#main-header` between the search box and `aux_nav`. Nothing from the remote theme is vendored, and a theme upgrade cannot silently drop this.

Social proof only. No "please star this repo" copy is added anywhere, and the footer is untouched.

## Implementation notes

- `margin-left: auto` — `.main-header` is `display: flex; justify-content: space-between`, so a third child would otherwise strand in the centre. This parks the badge against the aux links.
- The `<img>` carries `height` but deliberately **not** `width`: shields.io sizes the badge to its content, so a hardcoded width would squash the digits the day the count gains one. `min-width` on the wrapper reserves the horizontal space instead, which is what actually prevents layout shift.
- Below the `md` breakpoint the whole header is `display: none`, so this is desktop-only by the theme's own design.

## Verification

Built with the real CI image (`ghcr.io/actions/jekyll-build-pages:latest`, `INPUT_SOURCE=docs`). Asserted the badge renders inside `#main-header`, after the search box and before `aux-nav`, and points at the correct repo slug. Badge URL confirmed to resolve to a live count of 118.

🤖 Generated with [Claude Code](https://claude.com/claude-code)